### PR TITLE
Fixed the bug that will make tick crash on start

### DIFF
--- a/bin/tickprocessor-driver.js
+++ b/bin/tickprocessor-driver.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var tickprocessor = require('./tickprocessor');
+var tickprocessor = require('../lib/tickprocessor');
 var ArgumentsProcessor = tickprocessor.ArgumentsProcessor;
 var TickProcessor = tickprocessor.TickProcessor;
 var SnapshotLogProcessor = tickprocessor.SnapshotLogProcessor;


### PR DESCRIPTION
At bin/tickprocessor-driver.js:3:

``` javascript
var tickprocessor = require('./tickprocessor');
```

This code will make tick crash on startup.

So I changed this to

``` javascript
var tickprocessor = require('../lib/tickprocessor');
```

Now it works fine
