### PR TITLE
Mention compatible node versions as a requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-v8.log processor based on scripts in v8 distribution. 
+v8.log processor based on scripts in v8 distribution.
 Allows you to profile V8-based programs without installing V8 from source.
+
+### Requirements
+
+Node versions `0.9.11`-`0.10.12`.
 
 ### Install
 	$ npm install tick


### PR DESCRIPTION
To help users troubleshoot incompatible `node` versions the project should mention which versions work with the current build. I did a quick test and these seem to be the compatible versions.

It could be useful to introduce some sort of tag-system to pinpoint the correct `node-tick` version compatible with the desired `node` version.
