### PR TITLE
Ignore unknown code move events if --ignore-unknown is set.

### DIFF
--- a/bin/tickprocessor-driver.js
+++ b/bin/tickprocessor-driver.js
@@ -53,7 +53,7 @@ var entriesProviders = {
 var params = processArguments(process.argv.slice(2));
 var snapshotLogProcessor;
 if (params.snapshotLogFileName) {
-  snapshotLogProcessor = new SnapshotLogProcessor();
+  snapshotLogProcessor = new SnapshotLogProcessor(params.ignoreUnknown);
   snapshotLogProcessor.processLogFile(params.snapshotLogFileName, processTicks);
 }
 

--- a/lib/tickprocessor.js
+++ b/lib/tickprocessor.js
@@ -82,7 +82,7 @@ function parseState(s) {
 }
 
 
-function SnapshotLogProcessor() {
+function SnapshotLogProcessor(ignoreUnknown) {
   LogReader.call(this, {
       'code-creation': {
           parsers: [null, parseInt, parseInt, null, 'var-args'],
@@ -99,6 +99,7 @@ function SnapshotLogProcessor() {
           processor: this.processSnapshotPosition }});
 
   V8Profile.prototype.handleUnknownCode = function(operation, addr) {
+    if (ignoreUnknown) return;
     var op = Profile.Operation;
     switch (operation) {
       case op.MOVE:
@@ -207,6 +208,7 @@ function TickProcessor(
 
   V8Profile.prototype.handleUnknownCode = function(
       operation, addr, opt_stackPos) {
+    if (ignoreUnknown) return;
     var op = Profile.Operation;
     switch (operation) {
       case op.MOVE:


### PR DESCRIPTION
I don't like seeing a whole bunch of this in the output

```
...
Code move event for unknown code: 0xe4edbaf8ca0
Code move event for unknown code: 0xe4edbaf8d40
Code move event for unknown code: 0xe4edbaf8e00
Code move event for unknown code: 0xe4edbaf8ee0
Code move event for unknown code: 0xe4edbaf8fc0
Code move event for unknown code: 0xe4edbaf90a0
Code move event for unknown code: 0xe4edbaf9180
Code move event for unknown code: 0xe4edbaf9220
Code move event for unknown code: 0xe4edbaf92c0
Code move event for unknown code: 0xe4edbaf9380
Code move event for unknown code: 0xe4edbafa080
Code move event for unknown code: 0xe4edbafa140
Code move event for unknown code: 0xe4edbafa1e0
Code move event for unknown code: 0xe4edbafa280
Code move event for unknown code: 0xe4edbafa320
Code move event for unknown code: 0xe4edbafa3c0
Code move event for unknown code: 0xe4edbafa4c0
Code move event for unknown code: 0xe4edbafa580
Code move event for unknown code: 0xe4edbafa620
Code move event for unknown code: 0xe4edbafa720
Code move event for unknown code: 0xe4edbafa7c0
Code move event for unknown code: 0xe4edbafa920
...
```

And it seems like the `--ignore-unknown` flag should get rid of it, but currently it does not. This PR would fix that.

Granted, it would be great if node-tick understood the unknown codes, but it still works alright without them.
