### PR TITLE
more safely bind to console.log

### DIFF
--- a/lib/tickprocessor.js
+++ b/lib/tickprocessor.js
@@ -28,7 +28,7 @@
 var Profile   = require('./profile');
 var LogReader = require('./logreader');
 var ProfileView = require('./profile_view');
-var print = console.log;
+var print = console.log.bind(console);
 var fs = require('fs');
 
 function processFileLines(fileName, processLine, done) {


### PR DESCRIPTION
this allows the code to be run client-side without throwing 'Illegal Invocation' errors
